### PR TITLE
Add SQLFluff /format endpoint to the server

### DIFF
--- a/src/dbt_core_interface/project.py
+++ b/src/dbt_core_interface/project.py
@@ -6267,7 +6267,7 @@ if format_command:
             # NOTE: Formatting a string is not supported.
             LOGGER.info(f"formatting file: {sql_path}")
             sql = Path(sql_path)
-        if not sql:
+        if not sql_path:
             response.status = 400
             return {
                 "error": {

--- a/src/dbt_core_interface/project.py
+++ b/src/dbt_core_interface/project.py
@@ -119,9 +119,10 @@ if TYPE_CHECKING:
 
 try:
     import dbt_core_interface.state as dci_state
-    from dbt_core_interface.sqlfluff_util import lint_command
+    from dbt_core_interface.sqlfluff_util import format_command, lint_command
 except ImportError:
     dci_state = None
+    format_command = None
     lint_command = None
 
 # dbt-core-interface is designed for non-standard use. There is no
@@ -6230,6 +6231,76 @@ if lint_command:
             LOGGER.info(f"Linting succeeded")
             lint_result = {"result": [error for error in result]}
         return lint_result
+
+if format_command:
+
+    @route("/format", method="POST")
+    def format_sql(
+        runners: DbtProjectContainer,
+    ):
+        LOGGER.info(f"format_sql()")
+        # Project Support
+        project_runner = (
+            runners.get_project(request.get_header("X-dbt-Project"))
+            or runners.get_default_project()
+        )
+        LOGGER.info(f"got project: {project_runner}")
+        if not project_runner:
+            response.status = 400
+            return asdict(
+                ServerErrorContainer(
+                    error=ServerError(
+                        code=ServerErrorCode.ProjectNotRegistered,
+                        message=(
+                            "Project is not registered. Make a POST request to the /register"
+                            " endpoint first to register a runner"
+                        ),
+                        data={"registered_projects": runners.registered_projects()},
+                    )
+                )
+            )
+
+        sql_path = request.query.get("sql_path")
+        LOGGER.info(f"sql_path: {sql_path}")
+        if sql_path:
+            # Format a file
+            # NOTE: Formatting a string is not supported.
+            LOGGER.info(f"formatting file: {sql_path}")
+            sql = Path(sql_path)
+        if not sql:
+            response.status = 400
+            return {
+                "error": {
+                    "data": {},
+                    "message": (
+                        "No SQL file provided. Must provide a SQL file path."
+                    ),
+                }
+            }
+        try:
+            LOGGER.info(f"Calling format_command()")
+            format_command(
+                Path(project_runner.config.project_root),
+                sql=sql,
+                extra_config_path=(
+                    Path(request.query.get("extra_config_path"))
+                    if request.query.get("extra_config_path")
+                    else None
+                ),
+            )
+        except Exception as format_err:
+            logging.exception("Formatting failed")
+            response.status = 500
+            return {
+                "error": {
+                    "data": {},
+                    "message": str(format_err),
+                }
+            }
+        else:
+            LOGGER.info(f"Formatting succeeded")
+            format_result = {"result": None}
+        return format_result
 
 
 def run_server(runner: Optional[DbtProject] = None, host="localhost", port=8581):

--- a/src/dbt_core_interface/project.py
+++ b/src/dbt_core_interface/project.py
@@ -6267,19 +6267,23 @@ if format_command:
             # NOTE: Formatting a string is not supported.
             LOGGER.info(f"formatting file: {sql_path}")
             sql = Path(sql_path)
-        if not sql_path:
+        else:
+            # Format a string
+            LOGGER.info(f"formatting string")
+            sql = request.body.getvalue().decode("utf-8")
+        if not sql:
             response.status = 400
             return {
                 "error": {
                     "data": {},
                     "message": (
-                        "No SQL file provided. Must provide a SQL file path."
+                        "No SQL provided. Either provide a SQL file path or a SQL string to lint."
                     ),
                 }
             }
         try:
             LOGGER.info(f"Calling format_command()")
-            format_command(
+            temp_result, formatted_sql = format_command(
                 Path(project_runner.config.project_root),
                 sql=sql,
                 extra_config_path=(
@@ -6299,7 +6303,7 @@ if format_command:
             }
         else:
             LOGGER.info(f"Formatting succeeded")
-            format_result = {"result": None}
+            format_result = {"result": temp_result, "sql": formatted_sql}
         return format_result
 
 

--- a/src/dbt_core_interface/project.py
+++ b/src/dbt_core_interface/project.py
@@ -6331,7 +6331,13 @@ def run_server(runner: Optional[DbtProject] = None, host="localhost", port=8581)
 if __name__ == "__main__":
     import argparse
 
-    # logging.basicConfig(level=logging.INFO)
+    logging.basicConfig(level=logging.ERROR)
+
+    # Configure logging for 'dbt_core_interface' and 'dbt_core_interface.sqlfluff_util'
+    for logger_name in ['dbt_core_interface', 'dbt_core_interface.sqlfluff_util']:
+        logger = logging.getLogger(logger_name)
+        logger.setLevel(logging.INFO)
+
     parser = argparse.ArgumentParser(
         description="Run the dbt interface server. Defaults to the WSGIRefServer"
     )

--- a/src/dbt_core_interface/sqlfluff_util.py
+++ b/src/dbt_core_interface/sqlfluff_util.py
@@ -172,7 +172,7 @@ def format_command(
             res = lint_result.persist_changes(
                 formatter=formatter, fixed_file_suffix=""
             )
-        success = all(res.values())
+            success = all(res.values())
     return success
 
 

--- a/src/dbt_core_interface/sqlfluff_util.py
+++ b/src/dbt_core_interface/sqlfluff_util.py
@@ -178,6 +178,8 @@ def format_command(
     else:
         # Format a SQL file
         LOGGER.info(f"Formatting SQL file: {sql}")
+        before_modified = datetime.fromtimestamp(sql.stat().st_mtime).strftime('%Y-%m-%d %H:%M:%S')
+        LOGGER.info(f"Before fixing, modified: {before_modified}")
         result_sql = None
         lint_result = lnt.lint_paths(
             paths=[str(sql)],
@@ -197,8 +199,6 @@ def format_command(
             num_fixable = lint_result.num_violations(types=SQLLintError, fixable=True)
             if num_fixable > 0:
                 LOGGER.info(f"Fixing {num_fixable} errors in SQL file")
-                before_modified = datetime.fromtimestamp(sql.stat().st_mtime).strftime('%Y-%m-%d %H:%M:%S')
-                LOGGER.info(f"Before fixing, modified: {before_modified}")
                 res = lint_result.persist_changes(
                     formatter=formatter, fixed_file_suffix=""
                 )
@@ -206,6 +206,8 @@ def format_command(
                 LOGGER.info(f"After fixing, modified: {after_modified}")
                 LOGGER.info(f"File modification time has changes? {before_modified != after_modified}")
                 success = all(res.values())
+            else:
+                LOGGER.info("No fixable errors in SQL file")
     LOGGER.info(f"format_command returning success={success}, result_sql={result_sql[:100] if result_sql is not None else 'n/a'}")
     return success, result_sql
 


### PR DESCRIPTION
How to use it:
```
# Launch the server
python src/dbt_core_interface/project.py

# Register the dbt project with the server (one-time only). Providing absolute file
# paths to the project and profile directory is best.
curl -X POST \
     -H "Content-Type: application/json" \
     -H "X-dbt-Project: dbt_project" \
     -d '{
       "project_dir": "/Users/barry/dev/dbt-core-interface/tests/sqlfluff_templater/fixtures/dbt/dbt_project",
       "profiles_dir": "/Users/barry/dev/dbt-core-interface/tests/sqlfluff_templater/fixtures/dbt/profiles_yml",
       "target": "dev"
     }' \
     http://localhost:8581/register

# Format the file. Providing an absolute file path is best.
curl -X POST \
     -H "Content-Type: application/json" \
     -H "X-dbt-Project: dbt_project" \
     "http://localhost:8581/format?sql_path=/Users/barry/dev/dbt-core-interface/tests/sqlfluff_templater/fixtures/dbt/dbt_project/models/my_new_project/issue_1608.sql"
```