### PR TITLE
Dcv 2805 env var jinja template call isnt working in sources yaml for dbt core interface

### DIFF
--- a/src/dbt_core_interface/project.py
+++ b/src/dbt_core_interface/project.py
@@ -543,9 +543,7 @@ class DbtProject:
                 if (__dbt_major_version__, __dbt_minor_version__) >= (1, 8):
                     from dbt_common.clients.system import get_env
                     from dbt_common.context import set_invocation_context
-
                     set_invocation_context(get_env())
-
 
                 set_from_args(self.base_config, self.base_config)
                 # We can think of `RuntimeConfig` as a dbt-core "context" object

--- a/src/dbt_core_interface/project.py
+++ b/src/dbt_core_interface/project.py
@@ -540,6 +540,13 @@ class DbtProject:
         # has acquired the lock, TODO: Lets implement a debounce-like buffer here
         with self.parsing_mutex:
             if init:
+                if (__dbt_major_version__, __dbt_minor_version__) >= (1, 8):
+                    from dbt_common.clients.system import get_env
+                    from dbt_common.context import set_invocation_context
+
+                    set_invocation_context(get_env())
+
+
                 set_from_args(self.base_config, self.base_config)
                 # We can think of `RuntimeConfig` as a dbt-core "context" object
                 # where a `Project` meets a `Profile` and is a superset of them both


### PR DESCRIPTION
Balboa's `_loans.yml`
```
version: 2

sources:
  - name: LOANS
    database: "{{ env_var('DATACOVES__MAIN__DATABASE','DEFAULT') }}"
```

without this PR
```Error registering dbt project in Datacoves Power User <ContextVar name='DBT_INVOCATION_CONTEXT_VAR' at 0x120c18450>```

with it
```
127.0.0.1 - - [09/Aug/2024 09:29:04] "POST /register?project_dir=%2Fconfig%2Fworkspace%2Ftransform&profiles_dir=%2Fconfig%2F.dbt HTTP/1.1" 200 97
127.0.0.1 - - [09/Aug/2024 09:29:04] "GET /health HTTP/1.1" 200 261
127.0.0.1 - - [09/Aug/2024 09:29:04] "GET /health HTTP/1.1" 200 261
127.0.0.1 - - [09/Aug/2024 09:29:04] "GET /parse?reset=false HTTP/1.1" 200 42
```

manifest.json
```
"sources": {
    "source.balboa.LOANS.PERSONAL_LOANS": {
      "database": "BALBOA_DEV",
      [...]
```