### PR TITLE
[DCV-3454] Restore custom functionality of old v0.x

### DIFF
--- a/src/dbt_core_interface/dbt_templater/templater.py
+++ b/src/dbt_core_interface/dbt_templater/templater.py
@@ -45,6 +45,14 @@ class DbtTemplater(JinjaTemplater):
         """Gets the dbt version."""
         return self._dbt_version.to_version_string()
 
+    def _apply_dbt_builtins(self, config: FluffConfig | None) -> bool:
+        """DbtTemplater uses actual dbt compilation, not FunctionWrapper placeholders.
+
+        Returning False prevents SQLFluff from adding FunctionWrapper objects
+        (which lack .get() method) to the Jinja environment during slice_file analysis.
+        """
+        return False
+
     @large_file_check
     def process(  # pyright: ignore[reportIncompatibleMethodOverride]
         self,

--- a/src/dbt_core_interface/project.py
+++ b/src/dbt_core_interface/project.py
@@ -77,7 +77,7 @@ def _set_invocation_context() -> None:
 _set_invocation_context()
 
 logger = logging.getLogger(__name__)
-logger.setLevel(logging.DEBUG)
+logger.setLevel(getattr(logging, os.getenv("LOG_LEVEL", "INFO").upper(), logging.INFO))
 logger.addHandler(rich.logging.RichHandler())
 
 add_logger_to_manager(

--- a/src/dbt_core_interface/project.py
+++ b/src/dbt_core_interface/project.py
@@ -9,6 +9,7 @@ import contextlib
 import functools
 import gc
 import json
+import re
 import logging
 import os
 import shlex
@@ -674,6 +675,9 @@ class DbtProject:
         self, sql: str, node_id: str | None = None
     ) -> tuple[ManifestNode, t.Callable[[], None]]:
         """Create a temporary node for SQL execution/compilation."""
+        # Remove only the opening and closing snapshot tags, keep the body
+        sql = re.sub(r'{%\s*snapshot\b.*?%}', '', sql, flags=re.DOTALL)
+        sql = re.sub(r'{%\s*endsnapshot\s*%}', '', sql, flags=re.DOTALL)
         node_id = node_id or f"temp_node_{uuid.uuid4().hex[:8]}"
         sql_node = self.sql_parser.parse_remote(sql, node_id)
         process_node(self.runtime_config, self.manifest, sql_node)

--- a/src/dbt_core_interface/server.py
+++ b/src/dbt_core_interface/server.py
@@ -284,12 +284,13 @@ def run_sql(
         comp_res = runner.compile_sql(raw_sql)
     try:
         model_context = runner.generate_runtime_model_context(comp_res.node)
+        compiled_code = f"select * from ({model_context['compiled_code']}) as __server_query"
         query = runner.adapter.execute_macro(
             macro_name="get_show_sql",
             macro_resolver=runner.manifest,
             context_override=model_context,
             kwargs={
-                "compiled_code": model_context["compiled_code"],
+                "compiled_code": compiled_code,
                 "sql_header": model_context["config"].get("sql_header"),
                 "limit": limit,
             },

--- a/src/dbt_core_interface/server.py
+++ b/src/dbt_core_interface/server.py
@@ -9,6 +9,7 @@ v2 server.py if we ever want/need to change the interface.
 import json
 import logging
 import os
+import re
 import time
 import typing as t
 import uuid
@@ -284,18 +285,31 @@ def run_sql(
         comp_res = runner.compile_sql(raw_sql)
     try:
         model_context = runner.generate_runtime_model_context(comp_res.node)
-        compiled_code = f"select * from ({model_context['compiled_code']}) as __server_query"
-        query = runner.adapter.execute_macro(
-            macro_name="get_show_sql",
-            macro_resolver=runner.manifest,
-            context_override=model_context,
-            kwargs={
-                "compiled_code": compiled_code,
-                "sql_header": model_context["config"].get("sql_header"),
-                "limit": limit,
-            },
-        )
+        original_code = model_context["compiled_code"]
+        sql_header = model_context["config"].get("sql_header") or ""
+
+        # Check if query already has a LIMIT clause at the end - if so, execute as-is
+        query: str
+        has_limit = bool(re.search(r"\slimit\s+\d+(\s+offset\s+\d+)?\s*;?\s*$", original_code, re.IGNORECASE))
+
+        if has_limit:
+            query = f"{sql_header}\n{original_code}" if sql_header else original_code
+
+        else:
+            # Wrap in subquery to safely apply limit
+            compiled_code = f"select * from ({original_code}) as __server_query"
+            query = runner.adapter.execute_macro(
+                macro_name="get_show_sql",
+                macro_resolver=runner.manifest,
+                context_override=model_context,
+                kwargs={
+                    "compiled_code": compiled_code,
+                    "sql_header": sql_header,
+                    "limit": limit,
+                },
+            )
         exec_res = runner.execute_sql(t.cast(str, query), compile=False)  # pyright: ignore[reportInvalidCast]
+
     except Exception as e:
         response.status_code = 500
         return ServerErrorContainer(

--- a/src/dbt_core_interface/server.py
+++ b/src/dbt_core_interface/server.py
@@ -484,9 +484,14 @@ def parse_project(
 
 
 @app.get("/health")  # legacy extension support
+def health() -> dict[str, t.Any]:
+    """Health check for vscode-sqlfluff extension. Always returns ready if server is running."""
+    return {"result": {"status": "ready"}}
+
+
 @app.get("/api/v1/status")
 def status(runner: DbtProject = Depends(_get_runner)) -> dict[str, t.Any]:
-    """Health check endpoint to verify server status."""
+    """Status endpoint with project details."""
     return {
         "result": {
             "status": "ready",


### PR DESCRIPTION
## Overview

Restores custom functionality from v0.x that was lost during the v1.x refactor.

Related:
- https://github.com/datacoves/datacoves-power-user/pull/62
- https://github.com/datacoves/datacoves/pull/1365

## After Merge

Tag as `v1.1.5`

## Changes

### SQLFluff Templater Fix
- Override `_apply_dbt_builtins` to return `False`, preventing SQLFluff from wrapping dbt builtins in `FunctionWrapper` objects (which lack `.get()` method)
- This restores the behavior from v0.2.x using a different approach

### Snapshot Support
- Strip `{% snapshot %}` / `{% endsnapshot %}` tags in `_create_temp_node` before compilation
- Supersedes #16

### Query Execution
- Wrap compiled code in subquery to safely apply user LIMIT clause
- Don't apply default limit if an in-script LIMIT clause is already present

### Logging Fix
- Removed hardcoded `DEBUG` log level
- Now uses `LOG_LEVEL` env variable with `INFO` as default

### Health Endpoint
- Separated `/health` (simple ready check) from `/api/v1/status` (detailed project status)
- `/health` always returns ready if server is running - no project dependency

## ⚠️ Deployment Note

The production entrypoint in `datacoves/src/code-server/dbt-core-interface/src/bin/entrypoint.sh` needs to be updated:

```
- python -m dbt_core_interface.project --host 0.0.0.0 --port 8581
+ python -m dbt_core_interface.server --host 0.0.0.0 --port 8581
```

This is being done in https://github.com/datacoves/datacoves/pull/1365